### PR TITLE
Facilitate the construction of Filter

### DIFF
--- a/src/Domain/Criteria/Filter.php
+++ b/src/Domain/Criteria/Filter.php
@@ -16,9 +16,29 @@ final class Filter implements FilterInterface
         $this->value = $value;
     }
 
-    public static function from(FilterField $field, FilterOperator $operator, FilterValueInterface $value): self
+    public static function from(string $field, string $operator, string|int|array $value): self
     {
-        return new self($field, $operator, $value);
+        if (\is_int($value)) {
+            return new self(
+                FilterField::from($field),
+                FilterOperator::from($operator),
+                FilterIntValue::from($value)
+            );
+        }
+
+        if (\is_array($value)) {
+            return new self(
+                FilterField::from($field),
+                FilterOperator::from($operator),
+                FilterArrayValue::from($value)
+            );
+        }
+
+        return new self(
+            FilterField::from($field),
+            FilterOperator::from($operator),
+            FilterValue::from($value)
+        );
     }
 
     public function field(): FilterField

--- a/src/Domain/Criteria/Filter.php
+++ b/src/Domain/Criteria/Filter.php
@@ -11,6 +11,8 @@ final class Filter implements FilterInterface
 
     public function __construct(FilterField $field, FilterOperator $operator, FilterValueInterface $value)
     {
+        self::assertConsistency($operator, $value);
+
         $this->field = $field;
         $this->operator = $operator;
         $this->value = $value;
@@ -59,5 +61,17 @@ final class Filter implements FilterInterface
     public function accept(FilterVisitorInterface $visitor)
     {
         return $visitor->visitFilter($this);
+    }
+
+    private static function assertConsistency(FilterOperator $operator, FilterValueInterface $value): void
+    {
+        $isArrayOperator = \in_array($operator, [FilterOperator::IN, FilterOperator::NOT_IN], true);
+
+        if ($value instanceof FilterArrayValue) {
+            \assert($isArrayOperator, 'Operator must be IN or NOT IN for array values');
+            return;
+        }
+
+        \assert(false === $isArrayOperator, 'Operator must not be IN or NOT IN for non-array values');
     }
 }


### PR DESCRIPTION
## Changes

- refactor: filter form factory improvement
- refactor: add consistency assertion between operator and value in Filter constructor

## Example

### Before

```php
Filter::from(
    FilterField::from('external_reference'),
    FilterOperator::from(FilterOperator::EQUAL),
    FilterValue::from($externalReference->value()),
)
```

### Keep

```php
new Filter(
    FilterField::from('external_reference'),
    FilterOperator::from(FilterOperator::EQUAL),
    FilterValue::from($externalReference->value()),
)
```

### After
```php
Filter::from(
    'external_reference',
    FilterOperator::EQUAL,
    $externalReference->value(),
)
```

## Migration

- Option 1: Replace `Filter::from(` to `new Filter(`
- Option 2: Remove all Value Object instantiations during filter construction