### PR TITLE
Facilitate the construction of Order

### DIFF
--- a/src/Domain/Criteria/Order.php
+++ b/src/Domain/Criteria/Order.php
@@ -5,8 +5,8 @@ namespace Pccomponentes\Criteria\Domain\Criteria;
 
 final class Order
 {
-    private $orderBy;
-    private $orderType;
+    private OrderBy $orderBy;
+    private OrderType $orderType;
 
     public function __construct(OrderBy $orderBy, OrderType $orderType)
     {
@@ -14,9 +14,9 @@ final class Order
         $this->orderType = $orderType;
     }
 
-    public static function from(OrderBy $orderBy, OrderType $orderType): self
+    public static function from(string $orderBy, string $orderType): self
     {
-        return new self($orderBy, $orderType);
+        return new self(OrderBy::from($orderBy), OrderType::from($orderType));
     }
 
     public function orderBy(): OrderBy

--- a/src/Domain/Criteria/OrderType.php
+++ b/src/Domain/Criteria/OrderType.php
@@ -7,8 +7,8 @@ use PcComponentes\Ddd\Domain\Model\ValueObject\EnumValueObject;
 
 final class OrderType extends EnumValueObject
 {
-    const ASC = 'asc';
-    const DESC = 'desc';
+    public const ASC = 'asc';
+    public const DESC = 'desc';
 
     public static function fromAsc(): self
     {


### PR DESCRIPTION
## Changes
 
 - refactor: order from factory improvement

## Example

### Before

```php
Order::from(
    OrderBy::from('priority'),
    OrderType::from(OrderType::ASC),
)
```

### Keep

```php
new Order(
    OrderBy::from('priority'),
    OrderType::from(OrderType::ASC),
)
```

### After
```php
Order::from(
    'priority',
    OrderType::ASC,
)
```

## Migration

- Option 1: Replace `Order::from(` to `new Order(`
- Option 2: Remove all Value Object instantiations during Order construction